### PR TITLE
문서 전체 편집시 error/12 리턴 하는 경우

### DIFF
--- a/app.py
+++ b/app.py
@@ -1285,7 +1285,7 @@ def edit(name = None, name2 = None, num = None):
         curs.execute("select data from data where title = ?", [name])
         old = curs.fetchall()
         if(old):
-            if(not num and request.forms.otent != old[0][0]):
+            if(not num and request.forms.cotent != old[0][0]):
                 return(re_error(conn, '/error/12'))
 
             leng = leng_check(len(request.forms.otent), len(content))


### PR DESCRIPTION
안녕하세요? 오픈 나무 정말 잘 사용하고 있습니다. :) 

사용중에 특정 문서가 전체 편집시에 error/12를 항상 리턴 하는 경우가 있는데, 
관련 코드를 보다보니 오타 인듯한 부분이 있어 오타가 맞는지 여쭤보려고 PR날려봅니다.