### PR TITLE
bugfix -- file upload 에러 핸들링

### DIFF
--- a/route/func_upload.py
+++ b/route/func_upload.py
@@ -98,7 +98,7 @@ def func_upload_2(conn):
                 'upload'
             )
 
-            file_num += 1
+            if file_num: file_num += 1
 
         conn.commit()
 


### PR DESCRIPTION
 - file 하나를 업로드할 시 file_num = None 인 상태에서 +=1 하여 에러 발생
 - 업로드는 됨
 - 한 줄 추가해서 에러 해결