### PR TITLE
Paste Upload 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ views/before_namu
 views/acme
 views/sl_open
 views/nitori
+
+.DS_Store

--- a/route/edit.py
+++ b/route/edit.py
@@ -160,6 +160,8 @@ def edit_2(conn, name):
             imp = [name, wiki_set(), custom(), other2([' (' + sub + ')', 0])],
             data =  get_name + '''
                 <form method="post">
+                    <label for="pasteUploadToggle">이미지 복붙해서 첨부하기 &nbsp;</label>
+                    <input type="checkbox" name="pasteUploadToggle" onClick="togglePasteUploaderSwtich()" />
                     <script>do_stop_exit();</script>
                     ''' + edit_button() + '''
                     <textarea rows="25" id="content" placeholder="''' + p_text + '''" name="content">''' + html.escape(re.sub('\n$', '', data)) + '''</textarea>

--- a/views/main_css/js/upload_image_with_paste.js
+++ b/views/main_css/js/upload_image_with_paste.js
@@ -1,0 +1,58 @@
+let pasteUploadSwitch = false;
+function togglePasteUploaderSwtich() {
+  pasteUploadSwitch = !pasteUploadSwitch;
+  if (pasteUploadSwitch) {
+    const textarea = document.querySelector("textarea");
+    if (textarea) textarea.addEventListener("paste", pasteListener);
+    alert("이미지 복붙 업로드 활성화");
+  } else {
+    const textarea = document.querySelector("textarea");
+    if (textarea) textarea.removeEventListener("paste", pasteListener);
+    alert("이미지 복붙 업로드 비활성화");
+  }
+}
+
+function pasteListener(e) {
+  // find file
+  if (e.clipboardData && e.clipboardData.items) {
+    const items = e.clipboardData.items;
+    let haveImageInClipboard = false;
+    const formData = new FormData();
+    for (let i = 0; i < items.length; i++) {
+      if (items[i].type.indexOf("image") !== -1) {
+        const file = items[i].getAsFile();
+        const customName = prompt("파일 이름을 설정해주세요. (확장자는 생략)");
+        const customFile = new File([file], customName + ".png", { type: file.type });
+        formData.append("f_data[]", customFile);
+        haveImageInClipboard = true;
+        e.preventDefault();
+        break;
+      }
+    }
+    if (!haveImageInClipboard) return;
+
+    // send to server
+    fetch("/upload", {
+      method: "POST",
+      body: formData,
+    })
+      .then((res) => {
+        if (res.status === 200 || res.status === 201) {
+          const url = res.url;
+          alert(
+            `이미지 복붙 업로드 성공. 다음 텍스트로 본문에 삽입할 수 있습니다 : [[${url.replace(
+              /.*\/w\/file/,
+              "file"
+            )}]]`
+          );
+        } else {
+          console.error("[ERROR] PasteUpload Fail :", res.statusText);
+          alert("이미지 복붙 업로드에 실패했습니다. 파일명 중복일 수 있습니다.");
+        }
+      })
+      .catch((err) => {
+        console.error("[ERROR] PasteUpload Fail :", JSON.stringify(err), err);
+        alert("이미지 복붙 업로드에 실패했습니다. 파일명 중복일 수 있습니다.");
+      });
+  }
+}

--- a/views/main_css/js/upload_image_with_paste.js
+++ b/views/main_css/js/upload_image_with_paste.js
@@ -22,6 +22,7 @@ function pasteListener(e) {
       if (items[i].type.indexOf("image") !== -1) {
         const file = items[i].getAsFile();
         const customName = prompt("파일 이름을 설정해주세요. (확장자는 생략)");
+        if (!customName) return alert("취소되었습니다.")
         const customFile = new File([file], customName + ".png", { type: file.type });
         formData.append("f_data[]", customFile);
         haveImageInClipboard = true;
@@ -40,10 +41,8 @@ function pasteListener(e) {
         if (res.status === 200 || res.status === 201) {
           const url = res.url;
           alert(
-            `이미지 복붙 업로드 성공. 다음 텍스트로 본문에 삽입할 수 있습니다 : [[${url.replace(
-              /.*\/w\/file/,
-              "file"
-            )}]]`
+            `이미지 복붙 업로드 성공. 아래 텍스트로 본문에 삽입할 수 있습니다.
+[[${decodeURIComponent(url.replace(/.*\/w\/file/, "file"))}]]`
           );
         } else {
           console.error("[ERROR] PasteUpload Fail :", res.statusText);


### PR DESCRIPTION
베타 버전으로 봐주시면 좋을 것 같습니다. 이런 작업 처음이라 여러 부분 미흡해도 너그러이 보시고, 문제점은 지적 부탁드려요.

작동 원리
- edit 페이지에서 버튼을 눌러 paste upload mode 를 끄거나 킬 수 있게 해둠
- 이미지를 복붙하면, 클립보드 내에서 png 파일을 찾고 (화면 캡처는 OS 무관하게 png 인 듯) 있다면 업로드 시작 / 없다면 기존 작업 (= 붙여넣기) 진행
- 업로드는 major browser에서 제공하는 fetch 모듈을 사용. chrome latest 말고 테스트 해보지는 않음
- 에러 발생은 99% 파일명 중복이라 가정하였음. 
- 겸사겸사 .DS_Store도 gitignore에 추가.